### PR TITLE
remove minimum byte expectation from termios

### DIFF
--- a/comm.c
+++ b/comm.c
@@ -42,8 +42,8 @@ static bool configure_tty(int fd, int speed)
 	tty.c_cflag |= CS8 | CLOCAL | CREAD;
 	tty.c_lflag = 0;
 	tty.c_oflag = 0;
-	tty.c_cc[VMIN] = 1;
-	tty.c_cc[VTIME] = 5;
+	tty.c_cc[VMIN] = 0;
+	tty.c_cc[VTIME] = 20;
 	tty.c_iflag &= ~(ICRNL | IGNBRK | IXON | IXOFF | IXANY);
 
 	if (tcsetattr(fd, TCSANOW, &tty) != 0) {


### PR DESCRIPTION
on a idle line this sometimes freezes the read call
setting the inter-byte timeout to 2 seconds 